### PR TITLE
Remove SQS and EventBridge from serverless demo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7499,6 +7499,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -7811,6 +7812,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"

--- a/serverless/deploy.js
+++ b/serverless/deploy.js
@@ -10,14 +10,12 @@ let app = 'meeting';
 let region = 'us-east-1';
 let bucket = ``;
 let stack = ``;
-let useEventBridge = false;
 
 function usage() {
   console.log(`Usage: deploy.sh [-r region] [-b bucket] [-s stack] [-a application] [-e]`);
   console.log(`  -r, --region       Target region, default '${region}'`);
   console.log(`  -b, --s3-bucket    S3 bucket for deployment, required`);
   console.log(`  -s, --stack-name   CloudFormation stack name, required`);
-  console.log(`  -e, --event-bridge Enable EventBridge integration, default is no integration`);
   console.log(`  -h, --help         Show help and exit`);
 }
 
@@ -71,10 +69,6 @@ function parseArgs() {
       case '-s':
       case '--stack-name':
         stack = getArgOrExit(++i, args);
-        break;
-      case '-e':
-      case '--event-bridge':
-        useEventBridge = true;
         break;
       default:
         console.log(`Invalid argument ${args[i]}`);
@@ -151,21 +145,19 @@ spawnOrFail('sam', [
   './build/packaged.yaml',
   '--stack-name',
   `${stack}`,
-  '--parameter-overrides',
-  `UseEventBridge=${useEventBridge}`,
   '--capabilities',
   'CAPABILITY_IAM',
   '--region',
   `${region}`,
 ]);
-console.log('Amazon Chime SDK Meeting Demo URL: ');
+console.log('Amazon Chime SDK Smart Video Sending Demo URL: ');
 const output = spawnOrFail('aws', [
   'cloudformation',
   'describe-stacks',
   '--stack-name',
   `${stack}`,
   '--query',
-  'Stacks[0].Outputs[0].OutputValue',
+  'Stacks[0].Outputs[?OutputKey==`ApiURL`].OutputValue',
   '--output',
   'text',
   '--region',

--- a/serverless/template.yaml
+++ b/serverless/template.yaml
@@ -2,24 +2,15 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: 'AWS::Serverless-2016-10-31'
 Description: Amazon Chime SDK Smart Video Sending Demo
 
-Parameters:
-  UseEventBridge:
-    Description: Use EventBridge to process server side notifications
-    Default: false
-    Type: String
-    AllowedValues: [true, false]
-Conditions:
-  ShouldUseEventBridge: !Equals [true, !Ref UseEventBridge]
 Globals:
   Function:
-    Runtime: nodejs12.x
+    Runtime: nodejs14.x
     Timeout: 30
     MemorySize: 128
     Environment:
       Variables:
         MEETINGS_TABLE_NAME: !Ref Meetings
         ATTENDEES_TABLE_NAME: !Ref Attendees
-        SQS_QUEUE_ARN: !GetAtt MeetingNotificationsQueue.Arn
         BROWSER_LOG_GROUP_NAME: !Ref ChimeBrowserLogs
 Resources:
   ChimeMeetingsAccessPolicy:
@@ -93,13 +84,10 @@ Resources:
       KeySchema:
         - AttributeName: 'AttendeeId'
           KeyType: HASH
-  MeetingNotificationsQueue:
-    Type: AWS::SQS::Queue
   ChimeSdkIndexLambda:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs12.x
       CodeUri: src/
       Events:
         RootApi:
@@ -120,9 +108,6 @@ Resources:
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref Meetings
-      Environment:
-        Variables:
-          USE_EVENT_BRIDGE: !Ref UseEventBridge
       Events:
         Api1:
           Type: Api
@@ -139,9 +124,6 @@ Resources:
             TableName: !Ref Meetings
         - DynamoDBCrudPolicy:
             TableName: !Ref Attendees
-      Environment:
-        Variables:
-          USE_EVENT_BRIDGE: !Ref UseEventBridge
       Events:
         Api1:
           Type: Api
@@ -178,32 +160,6 @@ Resources:
           Properties:
             Path: /attendee
             Method: GET
-  ChimeSQSQueueLambda:
-    Type: AWS::Serverless::Function
-    Properties:
-      Handler: handlers.sqs_handler
-      CodeUri: src/
-      Events:
-        MeetingNotificationsEvent:
-          Type: SQS
-          Properties:
-            Queue: !GetAtt MeetingNotificationsQueue.Arn
-            BatchSize: 10
-  ChimeEventBridgeLambda:
-    Type: AWS::Serverless::Function
-    Condition: ShouldUseEventBridge
-    Properties:
-      Handler: handlers.event_bridge_handler
-      CodeUri: src/
-      Events:
-        ChimeEventBridgeEvent:
-          Type: CloudWatchEvent
-          Properties:
-            Pattern:
-              source:
-                - aws.chime
-              detail-type:
-                - 'Chime Meeting State Change'
   ChimeSdkBrowserLogsLambda:
     Type: AWS::Serverless::Function
     Properties:
@@ -215,22 +171,6 @@ Resources:
           Properties:
             Path: /logs
             Method: POST
-  ChimeNotificationsQueuePolicy:
-    Type: AWS::SQS::QueuePolicy
-    Properties:
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Action:
-              - sqs:SendMessage
-              - sqs:GetQueueUrl
-            Principal:
-              Service:
-                - chime.amazonaws.com
-            Resource: !GetAtt MeetingNotificationsQueue.Arn
-      Queues:
-        - Ref: MeetingNotificationsQueue
   ChimeBrowserLogs:
     Type: AWS::Logs::LogGroup
 


### PR DESCRIPTION
**Description of changes:**
- Remove SQS and EventBridge Lambdas to reduce the complexity as we already showcase how to set up notification event in other demos.
- Update Lambda Node version to 14.
- Update the URL output to ApiURL instead of hard coding the value.

**Testing**

1. How did you test these changes? Deployed and verified the demo worked.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
