### PR TITLE
Update the Chime SDK for JavaScript version to 2.30.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "amazon-chime-sdk-smart-video-sending-demo",
       "version": "1.0.0",
       "dependencies": {
         "@types/react": "^16.9.19",
@@ -13,7 +12,7 @@
         "@types/styled-components": "^5.0.0",
         "@types/uuid": "^8.3.0",
         "@types/webpack-env": "^1.15.1",
-        "amazon-chime-sdk-js": "^2.6.0",
+        "amazon-chime-sdk-js": "^2.30.0",
         "aws-sdk": "^2.642.0",
         "react": "^16.12.0",
         "react-dom": "^16.12.0",
@@ -1221,13 +1220,14 @@
       }
     },
     "node_modules/amazon-chime-sdk-js": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.23.0.tgz",
-      "integrity": "sha512-aacvZnYVzSWBQfSYrb1BRFnUoS//oUl8ZSgRqk2gR7oXcG4gcRRriHVdg5IY9rBbN78Xhdl0zHXa4lswkRQ8Tw==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.30.0.tgz",
+      "integrity": "sha512-XQjZk+Mqq1cx7RoTBkkGsJPk4BY0LmUmDLABF3tGYNvj3HCt1LdwUmW+xSQXJbaUXDF/nYCtIsWk2UlB3eOqkQ==",
       "dependencies": {
         "@types/dom-mediacapture-record": "^1.0.7",
         "@types/ua-parser-js": "^0.7.35",
         "detect-browser": "^5.2.0",
+        "pako": "^2.0.4",
         "protobufjs": "~6.8.8",
         "resize-observer": "^1.0.0",
         "ua-parser-js": "^1.0.1"
@@ -4052,6 +4052,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -7478,13 +7483,14 @@
       "requires": {}
     },
     "amazon-chime-sdk-js": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.23.0.tgz",
-      "integrity": "sha512-aacvZnYVzSWBQfSYrb1BRFnUoS//oUl8ZSgRqk2gR7oXcG4gcRRriHVdg5IY9rBbN78Xhdl0zHXa4lswkRQ8Tw==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-2.30.0.tgz",
+      "integrity": "sha512-XQjZk+Mqq1cx7RoTBkkGsJPk4BY0LmUmDLABF3tGYNvj3HCt1LdwUmW+xSQXJbaUXDF/nYCtIsWk2UlB3eOqkQ==",
       "requires": {
         "@types/dom-mediacapture-record": "^1.0.7",
         "@types/ua-parser-js": "^0.7.35",
         "detect-browser": "^5.2.0",
+        "pako": "^2.0.4",
         "protobufjs": "~6.8.8",
         "resize-observer": "^1.0.0",
         "ua-parser-js": "^1.0.1"
@@ -9613,6 +9619,11 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
+    },
+    "pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
     "param-case": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@types/styled-components": "^5.0.0",
     "@types/uuid": "^8.3.0",
     "@types/webpack-env": "^1.15.1",
-    "amazon-chime-sdk-js": "^2.6.0",
+    "amazon-chime-sdk-js": "^2.30.0",
     "aws-sdk": "^2.642.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",


### PR DESCRIPTION
**Issue #:**
- The demo does not work as expected with the deprecated Chime SDK for JavaScript v2.6.0.

**Description of changes:**
- Use the latest version of the Chime SDK for JavaScript.

**Testing**

1. How did you test these changes? Deployed the serverless demo for testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
