### PR TITLE
Fix the issue that toggling a local video has stopped working

### DIFF
--- a/src/providers/LocalVideoToggleProvider.tsx
+++ b/src/providers/LocalVideoToggleProvider.tsx
@@ -40,6 +40,7 @@ const LocalVideoToggleProvider: React.FC = ({ children }) => {
     if (isLocalVideoEnabled === 'enabled' || !meetingManager.selectedVideoInputDevice) {
       audioVideo?.stopLocalVideoTile();
       previewEle && audioVideo?.stopVideoPreviewForVideoInput(previewEle);
+      await audioVideo?.chooseVideoInputDevice(null);
       setIsLocalVideoEnabled('disabled');
       setNameplate("");
 


### PR DESCRIPTION
**Issue #:**
- N/A

**Description of changes:**
- Ensure that the demo selects the `null` device when turning the local video off.

**Testing**
- Deployed the serverless demo and verified that toggling the local video worked okay.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
